### PR TITLE
Fix ft_client argument parsing

### DIFF
--- a/ft_client/freqtrade_client/ft_client.py
+++ b/ft_client/freqtrade_client/ft_client.py
@@ -103,7 +103,11 @@ def main_exec(parsed: dict[str, Any]):
         return
 
     # Split arguments with = into key/value pairs
-    kwargs = {x.split("=")[0]: x.split("=")[1] for x in parsed["command_arguments"] if "=" in x}
+    kwargs = {
+        x.split("=", 1)[0]: x.split("=", 1)[1]
+        for x in parsed["command_arguments"]
+        if "=" in x
+    }
     args = [x for x in parsed["command_arguments"] if "=" not in x]
     try:
         res = getattr(client, command)(*args, **kwargs)


### PR DESCRIPTION
## Summary
- handle values containing '=' in ft_client argument parsing

## Testing
- `ruff check ft_client/freqtrade_client/ft_client.py`
- `pytest -q` *(fails: ImportError: cannot import name 'Undefined' from 'pydantic.fields')*

------
https://chatgpt.com/codex/tasks/task_e_68480ecf6fd88322b37cad73e25aadd7